### PR TITLE
[1.x] Fix: ReferenceError in JavaScript code preventing refresh

### DIFF
--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -1,12 +1,6 @@
 @once
     <script>
         // start-poke-script
-        if (typeof poke_reload_window === 'undefined') {
-            const poke_reload_window = () => {
-                window.location.reload();
-            };
-        }
-
         if (typeof poke_renew === 'undefined') {
             let poke_last = new Date();
 
@@ -28,7 +22,7 @@
 
             const poke_expire_check = () => {
                 if (navigator.onLine && new Date() - poke_last >= {{ $interval }} + {{ $lifetime }}) {
-                    poke_reload_window();
+                    window.location.reload();
                 }
             };
 


### PR DESCRIPTION
<!--
Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "[X.x] This new feature"
- Describe what the new feature enables
- Show a small code snippet of the new feature
- Ensure it doesn't break backward compatibility.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break backward compatibility.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.

If you're a Sponsor, this PR will have priority review.
Not a Sponsor? Become one at https://github.com/sponsors/DarkGhostHunter
-->

# Description

Const variables will be locally scoped to the block instead of scoped to the global object. Therefore, when the if body for `poke_reload_window`'s type executes, the `poke_reload_window` will only be defined in that if body's block.
This means that the call in `poke_expire_check` will not succeed as the function is not defined in that scope.
Hence a ReferenceError will occur and the page will not be refreshed. Fix this by just replacing the call to `poke_reload_window` by its contents.

More specifically, this is the error in the JS console: `Uncaught (in promise) ReferenceError: poke_reload_window is not defined`.

# Code samples

N/A. It is reproducible by having the poke script trying to refresh the page.
