### PR TITLE
[3.0] Update Laravel dendencies

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -53,14 +53,18 @@ jobs:
           - 8.1
           - 8.2
           - 8.3
+          - 8.4
         laravel-constraint:
           - 10.*
           - 11.*
+          - 12.*
         dependencies:
           - lowest
           - highest
         exclude:
           - laravel-constraint: 11.*
+            php-version: 8.1
+          - laravel-constraint: 12.*
             php-version: 8.1
     steps:
       - name: Set up PHP

--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,15 @@
     },
     "require": {
         "php": "^8.1",
-        "laragear/meta": "3.*",
-        "illuminate/http": "10.*|11.*",
-        "illuminate/routing": "10.*|11.*",
-        "illuminate/support": "10.*|11.*",
-        "illuminate/view": "10.*|11.*"
+        "laragear/meta": "3.*|4.*",
+        "illuminate/http": "10.*|11.*|12.*",
+        "illuminate/routing": "10.*|11.*|12.*",
+        "illuminate/support": "10.*|11.*|12.*",
+        "illuminate/view": "10.*|11.*|12.*"
     },
     "require-dev": {
-        "laragear/meta-testing": "2.*",
-        "orchestra/testbench": "8.*|9.*"
+        "laragear/meta-testing": "2.*|3.*",
+        "orchestra/testbench": "8.*|9.*|10.*"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Http/Middleware/InjectScript.php
+++ b/src/Http/Middleware/InjectScript.php
@@ -28,7 +28,7 @@ class InjectScript
     /**
      * Handle the incoming request.
      */
-    public function handle(Request $request, Closure $next, string $force = null): mixed
+    public function handle(Request $request, Closure $next, ?string $force = null): mixed
     {
         $response = $next($request);
 

--- a/tests/Http/RouteGeneratorTest.php
+++ b/tests/Http/RouteGeneratorTest.php
@@ -15,6 +15,8 @@ class RouteGeneratorTest extends TestCase
             'domain' => null,
             'middleware' => 'test-middleware',
         ]);
+
+        $app->make('config')->set('filesystems.disks.local.serve', false);
     }
 
     /**
@@ -69,6 +71,8 @@ class RouteGeneratorTest extends TestCase
             'domain' => ['one', 'two', 'three'],
             'middleware' => 'test-middleware',
         ]);
+
+        $app->make('config')->set('filesystems.disks.local.serve', false);
     }
 
     /**


### PR DESCRIPTION
- Update composer.json Laravel versions
- Update test matrix
- Update tests to ignore the `storage.local` route

# Description
Update dependencies to allow for Laravel 12

# Testing

```bash
php vendor/bin/phpunit
```
